### PR TITLE
Fix line 818

### DIFF
--- a/BridgeEmulator/HueEmulator.py
+++ b/BridgeEmulator/HueEmulator.py
@@ -815,7 +815,7 @@ def description():
 <URLBase>http://""" + getIpAddress() + """:80/</URLBase>
 <device>
 <deviceType>urn:schemas-upnp-org:device:Basic:1</deviceType>
-<friendlyName>og hue bridge (""" + getIpAddress() + """)</friendlyName>
+<friendlyName>Phillips hue (""" + getIpAddress() + """)</friendlyName>
 <manufacturer>Royal Philips Electronics</manufacturer>
 <manufacturerURL>http://www.philips.com</manufacturerURL>
 <modelDescription>Philips hue Personal Wireless Lighting</modelDescription>

--- a/BridgeEmulator/HueEmulator.py
+++ b/BridgeEmulator/HueEmulator.py
@@ -815,7 +815,7 @@ def description():
 <URLBase>http://""" + getIpAddress() + """:80/</URLBase>
 <device>
 <deviceType>urn:schemas-upnp-org:device:Basic:1</deviceType>
-<friendlyName>Phillips hue (""" + getIpAddress() + """)</friendlyName>
+<friendlyName>Philips hue (""" + getIpAddress() + """)</friendlyName>
 <manufacturer>Royal Philips Electronics</manufacturer>
 <manufacturerURL>http://www.philips.com</manufacturerURL>
 <modelDescription>Philips hue Personal Wireless Lighting</modelDescription>


### PR DESCRIPTION
Reverted line 818 to before you fixed the description.xml earlier (to fix #95 & #117 ), as "og hue bridge" is the custom name I gave my real bridge via the hue app so I know it's the real one and not the emulator. Also, after seeing that the custom name is in the description.xml, it should probably populate and match the name the bridge is given/shown in the hue app, might be the reason some apps aren't working