### PR TITLE
Added Yeelight Color Support

### DIFF
--- a/BridgeEmulator/HueEmulator3.py
+++ b/BridgeEmulator/HueEmulator3.py
@@ -502,12 +502,6 @@ def convert_xy(x, y, bri): #needed for milight hub that don't work with xy value
     r = 0 if r < 0 else r
     g = 0 if g < 0 else g
     b = 0 if b < 0 else b 
-    print(r)
-    print(r * bri)
-    print(g)
-    print(g * bri)
-    print(b)
-    print(b * bri)
     return [int(r * bri), int(g * bri), int(b * bri)]
     
 def hsv_to_rgb(h, s, v): 

--- a/BridgeEmulator/HueEmulator3.py
+++ b/BridgeEmulator/HueEmulator3.py
@@ -415,8 +415,10 @@ def sendRequest(url, method, data, timeout=3, delay=0):
             api_method = "set_bright"
             param = str(decode["brightness"])
         elif decode["request"] == "set_ct_abx":
-            api_method = decode["request"]
-            param = decode["color_temp"]
+            api_method = "set_ct_abx"
+            temp = decode["color_temp"]
+            param = str(temp) + ", \"smooth\", 500"
+            print(param)
         elif decode["request"] == "set_hsv":
             api_method = decode["request"]
             param = decode["hue"] + ", " + decode["sat"]
@@ -585,7 +587,7 @@ def sendLightRequest(light, data):
                     payload["brightness"] = int(value / 2.55)
                 elif key == "ct":
                     payload["request"] = "set_ct_abx"
-                    payload["color_temp"] = value
+                    payload["color_temp"] = int(1000000 / value)
                 elif key == "hue":
                     payload["request"] = "set_hsv"
                     payload["hue"] = value / 180

--- a/BridgeEmulator/HueEmulator3.py
+++ b/BridgeEmulator/HueEmulator3.py
@@ -401,7 +401,6 @@ def sendRequest(url, method, data, timeout=3, delay=0):
     elif method == "TCP":
         if "//" in url: # cutting out the http://
             http, url = url.split("//",1)
-        print(url)
         decode = json.loads(data)   #initialising vars
         api_method=""
         param = ""
@@ -445,8 +444,6 @@ def sendToYeelight(url, api_method, param):
         tcp_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         tcp_socket.connect((url, int(55443)))
         msg="{\"id\":" + str(1) + ",\"method\":\"" +  api_method +  "\",\"params\":[" + param + "]}\r\n"
-        print("Message")                
-        print(msg)
         tcp_socket.send(msg.encode())
         tcp_socket.close()
     except Exception as e:
@@ -618,11 +615,8 @@ def sendLightRequest(light, data):
                 elif key == "xy":
                     color = convert_xy(value[0], value[1], bridge_config["lights"][light]["state"]["bri"])        
                     payload["request"] = "set_rgb"
-                    code = (color[0] * 65536) + (color[1] * 256) + color[2]
+                    code = (color[0] * 65536) + (color[1] * 256) + color[2] #according to docs, yeelight needs this to set rgb. its r * 65536 + g * 256 + b
                     payload["rgb"] = code
-                    # (payload["color"]["r"], payload["color"]["g"], payload["color"]["b"]) = 
-                    
-            print("Gehe über zum senden")
             print(json.dumps(payload))
         elif bridge_config["lights_address"][light]["protocol"] == "ikea_tradfri": #IKEA Tradfri bulb
             url = "coaps://" + bridge_config["lights_address"][light]["ip"] + ":5684/15001/" + str(bridge_config["lights_address"][light]["device_id"])
@@ -803,7 +797,6 @@ def syncWithLights(): #update Hue Bridge lights states
                             line = {"result": ["invalid command"]}
 
                         if line.get("method") != "props":
-                            # This is probably the response we want.
                             response = line
                         else:
                             print ("error")


### PR DESCRIPTION
I've added Support for the Yeelight Color.
What I've sucessfully tested:
* Power 
* Brightness
* color temp
* recipes

Add Yeelight via ```/yeelight ```

Some More Infos:
I've implemented an new Method TCP (Line 401) to talk to the bulp via tcp socket
The Yeelight doesnt support multiple commands at once. 
But Scences etc seems to send something like Power On, Brightness 50 and Color red in one json.. so I had to check for each availible command once and then instantly send.. so I've aded the sendToYeelight function. 


**Note 
I know there are there are White only Yeelights, thats why I added the Color in the HTML entry page.