### PR TITLE
Update to SK6812HueStrip.ino

### DIFF
--- a/Lights/Arduino/SK6812HueStrip/SK6812HueStrip.ino
+++ b/Lights/Arduino/SK6812HueStrip/SK6812HueStrip.ino
@@ -525,7 +525,9 @@ void setup() {
   });
 
   server.on("/detect", []() {
-    server.send(200, "text/plain", "{\"hue\": \"strip\",\"lights\": " + (String)lightsCount + ",\"modelid\": \"LST001\",\"mac\": \"" + String(mac[5], HEX) + ":"  + String(mac[4], HEX) + ":" + String(mac[3], HEX) + ":" + String(mac[2], HEX) + ":" + String(mac[1], HEX) + ":" + String(mac[0], HEX) + "\"}");
+    char macString[50] = {0};
+    sprintf(macString,"%02X:%02X:%02X:%02X:%02X:%02X",mac[0],mac[1],mac[2],mac[3],mac[4],mac[5]);
+    server.send(200, "text/plain", "{\"hue\": \"strip\",\"lights\": " + (String)lightsCount + ",\"modelid\": \"LST002\",\"mac\": \"" + String(macString) + "\"}");
   });
 
   server.on("/", []() {


### PR DESCRIPTION
Hi Marius,

I was able to get this sketch working with an SK6812 strip after updating modelid to LST002.

Noticed the mac address returned by http://<light_ip>/detect was backwards and leaving off leading zeros so I changed that as well.

Can also confirm same issue already reported with official Hue App v3.1.0 on iphone refusing to connect to my bridge emulated on a Pi Zero W.

Thanks!
Brian