### PR TITLE
Update docker usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ Contributions are welcomed
 Hue living color light project for 3D printing: https://www.thingiverse.com/thing:2773413
 
 ## Docker:
-There are currently two docker images available. One for x86 systems and one for ARM systems (Raspberry Pi). Currently the ARM image has only been tested with a Raspberry Pi 3b+ If you have other ARM based devices and can test the image, please let us know on our Slack chat or in an issue. The imageas can be run with the following commands.
+There are currently two docker images available. One for x86 systems and one for ARM systems (Raspberry Pi). Currently the ARM image has only been tested with a Raspberry Pi 3b+ If you have other ARM based devices and can test the image, please let us know on our Slack chat or in an issue. The images can be run with both host and bridge network modes. I recomend using the host network mode for ease, however this will give you less controll over your docker networks. Using bridge mode allows you to controll the traffic in and out of the container but requires more options to setup.
+
+To run the container with the host network mode:
 
 x86:
 
@@ -97,6 +99,18 @@ x86:
 ARM:
 
 `docker run -d --name "diyHue" --network="host" -v '/mnt/hue-emulator/export/':'/opt/hue-emulator/export/':'rw' cheesemarathon/diyhue:arm-latest`
+
+When running with the bridge network mode you must provide the IP and MAC address of the host device. Four ports are also opened to the container. These port mappings must not be changed as the hue ecosystem expects to communicate over specific ports.
+
+To run the container with bridge network mode:
+
+x86:
+
+`docker run -d --name "diyHue" --network="bridge" -v '/mnt/hue-emulator/export/':'/opt/hue-emulator/export/':'rw' -e 'MAC=XX:XX:XX:XX:XX:XX' -e 'IP=XX.XX.XX.XX' -p 80:80/tcp -p 443:443/tcp -p 1900:1900/udp -p 2100:2100/udp cheesemarathon/diyhue:latest`
+
+ARM:
+
+`docker run -d --name "diyHue" --network="bridge" -v '/mnt/hue-emulator/export/':'/opt/hue-emulator/export/':'rw' -e 'MAC=XX:XX:XX:XX:XX:XX' -e 'IP=XX.XX.XX.XX' -p 80:80/tcp -p 443:443/tcp -p 1900:1900/udp -p 2100:2100/udp  cheesemarathon/diyhue:arm-latest`
 
 These commands will run the latest image available, however if you have automated updates enabled with a service such as [watchtower](https://github.com/v2tec/watchtower) then using latest is not recomended. The images are automatically rebuilt upon a new commit to this repo. As such, larges changes could occur and updates will be frequent. Each image is also taged with the comit hash. For example cheesemarathon/diyhue:arm-aa592a7 or cheesemarathon/diyhue:aa592a7. It is then suggested you use one of these images instead and manually update every so often.
 


### PR DESCRIPTION
Updates the docker instructions to reflect the option to use both bridge and host network modes