### PR TITLE
Use defines to enable static IP configuration

### DIFF
--- a/Lights/Arduino/EspLight-fridgefire/EspLight-fridgefire.ino
+++ b/Lights/Arduino/EspLight-fridgefire/EspLight-fridgefire.ino
@@ -28,10 +28,12 @@ uint32 io_info[PWM_CHANNELS][3] = {
 // initial duty: all off
 uint32 pwm_duty_init[PWM_CHANNELS] = {0, 0, 0};
 
-// if you want to setup static ip uncomment these 3 lines and line 316
-//IPAddress strip_ip ( 192,  168,   10,  95);
-//IPAddress gateway_ip ( 192,  168,   10,   1);
-//IPAddress subnet_mask(255, 255, 255,   0);
+//#define USE_STATIC_IP //! uncomment to enable Static IP Adress
+#ifdef USE_STATIC_IP
+IPAddress strip_ip ( 192,  168,   0,  95); // choose an unique IP Adress
+IPAddress gateway_ip ( 192,  168,   0,   1); // Router IP
+IPAddress subnet_mask(255, 255, 255,   0);
+#endif
 
 uint8_t rgb_multiplier[] = {100, 90, 30}; // light multiplier in percentage, max = 100
 uint8_t rgb[3], color_mode, scene;
@@ -313,7 +315,9 @@ void setup() {
   pwm_init(period, pwm_duty_init, PWM_CHANNELS, io_info);
   pwm_start();
 
-  //WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#ifdef USE_STATIC_IP
+  WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#endif
 
   apply_scene(EEPROM.read(2));
   for (uint8_t color = 0; color < PWM_CHANNELS; color++) {

--- a/Lights/Arduino/Generic_CCT_Light/Generic_CCT_Light.ino
+++ b/Lights/Arduino/Generic_CCT_Light/Generic_CCT_Light.ino
@@ -34,10 +34,12 @@ uint32 io_info[PWM_CHANNELS][3] = {
 uint32 pwm_duty_init[PWM_CHANNELS] = {0, 0};
 
 
-// if you want to setup static ip uncomment these 3 lines and line 180
-//IPAddress strip_ip ( 192,  168,   10,  95);
-//IPAddress gateway_ip ( 192,  168,   10,   1);
-//IPAddress subnet_mask(255, 255, 255,   0);
+//#define USE_STATIC_IP //! uncomment to enable Static IP Adress
+#ifdef USE_STATIC_IP
+IPAddress strip_ip ( 192,  168,   0,  95); // choose an unique IP Adress
+IPAddress gateway_ip ( 192,  168,   0,   1); // Router IP
+IPAddress subnet_mask(255, 255, 255,   0);
+#endif
 
 uint8_t cct[2], scene;
 bool light_state, in_transition;
@@ -176,8 +178,11 @@ void setup() {
 
   pwm_init(period, pwm_duty_init, PWM_CHANNELS, io_info);
   pwm_start();
+  
+#ifdef USE_STATIC_IP
+  WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#endif
 
-  //WiFi.config(strip_ip, gateway_ip, subnet_mask);
 
   apply_scene(EEPROM.read(2));
   step_level[0] = cct[0] / 150.0; step_level[1] = cct[1] / 150.0;

--- a/Lights/Arduino/Generic_Dimmable_Light/Generic_Dimmable_Light.ino
+++ b/Lights/Arduino/Generic_Dimmable_Light/Generic_Dimmable_Light.ino
@@ -31,10 +31,12 @@ uint32 io_info[lightsCount][3] = {
 uint32 pwm_duty_init[lightsCount];
 //uint32 pwm_duty_init[lightsCount] = {512, 255}; this will set startup brightness to 50% on first light and 25% on second one
 
-// if you want to setup static ip uncomment these 3 lines and line 156
-//IPAddress strip_ip ( 192,  168,   10,  95);
-//IPAddress gateway_ip ( 192,  168,   10,   1);
-//IPAddress subnet_mask(255, 255, 255,   0);
+//#define USE_STATIC_IP //! uncomment to enable Static IP Adress
+#ifdef USE_STATIC_IP
+IPAddress strip_ip ( 192,  168,   0,  95); // choose an unique IP Adress
+IPAddress gateway_ip ( 192,  168,   0,   1); // Router IP
+IPAddress subnet_mask(255, 255, 255,   0);
+#endif
 
 uint8_t scene;
 bool light_state[lightsCount], in_transition;
@@ -152,8 +154,10 @@ void lightEngine() {
 
 void setup() {
   EEPROM.begin(512);
-
-  //WiFi.config(strip_ip, gateway_ip, subnet_mask);
+  
+#ifdef USE_STATIC_IP
+  WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#endif
 
   for (uint8_t ch = 0; ch < lightsCount; ch++) {
     pinMode(io_info[ch][2], OUTPUT);

--- a/Lights/Arduino/Generic_ON_OFF_device/Generic_ON_OFF_device.ino
+++ b/Lights/Arduino/Generic_ON_OFF_device/Generic_ON_OFF_device.ino
@@ -11,10 +11,12 @@
 uint8_t devicesPins[devicesCount] = {12, 13, 14, 5};
 
 
-// if you want to setup static ip uncomment these 3 lines and line 47
-//IPAddress strip_ip ( 192,  168,   10,  95);
-//IPAddress gateway_ip ( 192,  168,   10,   1);
-//IPAddress subnet_mask(255, 255, 255,   0);
+//#define USE_STATIC_IP //! uncomment to enable Static IP Adress
+#ifdef USE_STATIC_IP
+IPAddress strip_ip ( 192,  168,   0,  95); // choose an unique IP Adress
+IPAddress gateway_ip ( 192,  168,   0,   1); // Router IP
+IPAddress subnet_mask(255, 255, 255,   0);
+#endif
 
 bool device_state[devicesCount];
 byte mac[6];
@@ -44,7 +46,9 @@ void setup() {
     pinMode(devicesPins[ch], OUTPUT);
   }
 
-  //WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#ifdef USE_STATIC_IP
+  WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#endif
 
 
   if (EEPROM.read(1) == 1 || (EEPROM.read(1) == 0 && EEPROM.read(0) == 1)) {

--- a/Lights/Arduino/Generic_ON_OFF_device_433Mhz/Generic_ON_OFF_device_433Mhz.ino
+++ b/Lights/Arduino/Generic_ON_OFF_device_433Mhz/Generic_ON_OFF_device_433Mhz.ino
@@ -42,11 +42,12 @@ int c;
 
 
 
-
-// if you want to setup static ip uncomment these 3 lines and line 115
-//IPAddress strip_ip ( 192,  168,   10,  95);
-//IPAddress gateway_ip ( 192,  168,   10,   1);
-//IPAddress subnet_mask(255, 255, 255,   0);
+//#define USE_STATIC_IP //! uncomment to enable Static IP Adress
+#ifdef USE_STATIC_IP
+IPAddress strip_ip ( 192,  168,   0,  95); // choose an unique IP Adress
+IPAddress gateway_ip ( 192,  168,   0,   1); // Router IP
+IPAddress subnet_mask(255, 255, 255,   0);
+#endif
 
 bool device_state[devicesCount];
 byte mac[6];
@@ -112,7 +113,10 @@ void setup() {
     pinMode(devicesPins[ch], OUTPUT);
   }
 
-  //WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#ifdef USE_STATIC_IP
+  WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#endif
+
 
 
   if (EEPROM.read(1) == 1 || (EEPROM.read(1) == 0 && EEPROM.read(0) == 1)) {

--- a/Lights/Arduino/Generic_RGBW_Light/Generic_RGBW_Light.ino
+++ b/Lights/Arduino/Generic_RGBW_Light/Generic_RGBW_Light.ino
@@ -21,10 +21,12 @@
 //define pins
 uint8_t pins[PWM_CHANNELS] = {12, 13, 14, 5}; //red, green, blue, white
 
-// if you want to setup static ip uncomment these 3 lines and line 72
-//IPAddress strip_ip ( 192,  168,   10,  95);
-//IPAddress gateway_ip ( 192,  168,   10,   1);
-//IPAddress subnet_mask(255, 255, 255,   0);
+//#define USE_STATIC_IP //! uncomment to enable Static IP Adress
+#ifdef USE_STATIC_IP
+IPAddress strip_ip ( 192,  168,   0,  95); // choose an unique IP Adress
+IPAddress gateway_ip ( 192,  168,   0,   1); // Router IP
+IPAddress subnet_mask(255, 255, 255,   0);
+#endif
 
 uint8_t colors[PWM_CHANNELS], bri, sat, color_mode, scene;
 bool light_state, in_transition;
@@ -300,7 +302,9 @@ void setup() {
     analogWrite(pins[pin], 0);
   }
 
-  //WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#ifdef USE_STATIC_IP
+  WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#endif
 
   apply_scene(EEPROM.read(2));
   step_level[0] = colors[0] / 150.0; step_level[1] = colors[1] / 150.0; step_level[2] = colors[2] / 150.0; step_level[3] = colors[3] / 150.0;

--- a/Lights/Arduino/Generic_RGB_CCT_Light/Generic_RGB_CCT_Light.ino
+++ b/Lights/Arduino/Generic_RGB_CCT_Light/Generic_RGB_CCT_Light.ino
@@ -21,10 +21,14 @@
 //define pins
 uint8_t pins[PWM_CHANNELS] = {13, 14, 12, 4, 5}; //red, green, blue, could white, warm white
 
-// if you want to setup static ip uncomment these 3 lines and line 72
-//IPAddress strip_ip ( 192,  168,   10,  95);
-//IPAddress gateway_ip ( 192,  168,   10,   1);
-//IPAddress subnet_mask(255, 255, 255,   0);
+
+//#define USE_STATIC_IP //! uncomment to enable Static IP Adress
+#ifdef USE_STATIC_IP
+IPAddress strip_ip ( 192,  168,   0,  95); // choose an unique IP Adress
+IPAddress gateway_ip ( 192,  168,   0,   1); // Router IP
+IPAddress subnet_mask(255, 255, 255,   0);
+#endif
+
 
 uint8_t colors[PWM_CHANNELS], bri, sat, color_mode, scene;
 bool light_state, in_transition;
@@ -297,7 +301,9 @@ void setup() {
     analogWrite(pins[pin], 0);
   }
 
-  //WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#ifdef USE_STATIC_IP
+  WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#endif
 
   apply_scene(EEPROM.read(2));
   step_level[0] = colors[0] / 150.0; step_level[1] = colors[1] / 150.0; step_level[2] = colors[2] / 150.0; step_level[3] = colors[3] / 150.0; step_level[4] = colors[4] / 150.0;

--- a/Lights/Arduino/Generic_RGB_Light/Generic_RGB_Light.ino
+++ b/Lights/Arduino/Generic_RGB_Light/Generic_RGB_Light.ino
@@ -21,10 +21,12 @@
 //define pins
 uint8_t pins[PWM_CHANNELS] = {12, 13, 14}; //red, green, blue
 
-// if you want to setup static ip uncomment these 3 lines and line 72
-//IPAddress strip_ip ( 192,  168,   10,  95);
-//IPAddress gateway_ip ( 192,  168,   10,   1);
-//IPAddress subnet_mask(255, 255, 255,   0);
+//#define USE_STATIC_IP //! uncomment to enable Static IP Adress
+#ifdef USE_STATIC_IP
+IPAddress strip_ip ( 192,  168,   0,  95); // choose an unique IP Adress
+IPAddress gateway_ip ( 192,  168,   0,   1); // Router IP
+IPAddress subnet_mask(255, 255, 255,   0);
+#endif
 
 uint8_t colors[PWM_CHANNELS], bri, sat, color_mode, scene;
 bool light_state, in_transition;
@@ -301,7 +303,9 @@ void setup() {
     analogWrite(pins[pin], 0);
   }
 
-  //WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#ifdef USE_STATIC_IP
+  WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#endif
 
   apply_scene(EEPROM.read(2));
   step_level[0] = colors[0] / 150.0; step_level[1] = colors[1] / 150.0; step_level[2] = colors[2] / 150.0; step_level[3] = colors[3] / 150.0;

--- a/Lights/Arduino/MY92XX_RGBW_Light/MY92XX_RGBW_Light.ino
+++ b/Lights/Arduino/MY92XX_RGBW_Light/MY92XX_RGBW_Light.ino
@@ -18,10 +18,12 @@ uint8_t PWM_PINS[PWM_CHANNELS] = {4, 3, 5, 6}; //RGBW order
 
 my92xx * _my92xx;
 
-// if you want to setup static ip uncomment these 3 lines and line 256
-//IPAddress strip_ip ( 192,  168,   10,  95);
-//IPAddress gateway_ip ( 192,  168,   10,   1);
-//IPAddress subnet_mask(255, 255, 255,   0);
+//#define USE_STATIC_IP //! uncomment to enable Static IP Adress
+#ifdef USE_STATIC_IP
+IPAddress strip_ip ( 192,  168,   0,  95); // choose an unique IP Adress
+IPAddress gateway_ip ( 192,  168,   0,   1); // Router IP
+IPAddress subnet_mask(255, 255, 255,   0);
+#endif
 
 uint8_t rgbw[4], color_mode, scene;
 bool light_state, in_transition;
@@ -253,7 +255,9 @@ void setup() {
   _my92xx = new my92xx(MY92XX_MODEL, MY92XX_CHIPS, MY92XX_DI_PIN, MY92XX_DCKI_PIN, MY92XX_COMMAND_DEFAULT);
   _my92xx->setState(true);
 
-  //WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#ifdef USE_STATIC_IP
+  WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#endif
 
   apply_scene(EEPROM.read(2));
   step_level[0] = rgbw[0] / 150.0; step_level[1] = rgbw[1] / 150.0; step_level[2] = rgbw[2] / 150.0; step_level[3] = rgbw[3] / 150.0;

--- a/Lights/Arduino/SK6812HueStrip/SK6812HueStrip.ino
+++ b/Lights/Arduino/SK6812HueStrip/SK6812HueStrip.ino
@@ -16,10 +16,12 @@
 #define button2_pin 5 // off and bri down
 #define use_hardware_switch false // on/off state and brightness can be controlled with above gpio pins. Is mandatory to connect them to ground with 10K resistors
 
-// if you want to setup static ip uncomment these 3 lines and line 326
-//IPAddress strip_ip ( 192,  168,   10,  95);
-//IPAddress gateway_ip ( 192,  168,   10,   1);
-//IPAddress subnet_mask(255, 255, 255,   0);
+//#define USE_STATIC_IP //! uncomment to enable Static IP Adress
+#ifdef USE_STATIC_IP
+IPAddress strip_ip ( 192,  168,   0,  95); // choose an unique IP Adress
+IPAddress gateway_ip ( 192,  168,   0,   1); // Router IP
+IPAddress subnet_mask(255, 255, 255,   0);
+#endif
 
 int lightLedsCount = pixelCount / lightsCount;
 uint8_t rgbw[lightsCount][4], bri[lightsCount], sat[lightsCount], color_mode[lightsCount], scene;
@@ -400,7 +402,9 @@ void setup() {
   EEPROM.begin(512);
   WiFi.hostname(light_name);
 
-  //WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#ifdef USE_STATIC_IP
+  WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#endif
 
   for (uint8_t light = 0; light < lightsCount; light++) {
     float transitiontime = (16 - (pixelCount / 40)) * 4;

--- a/Lights/Arduino/Sonoff_S20/Sonoff_S20.ino
+++ b/Lights/Arduino/Sonoff_S20/Sonoff_S20.ino
@@ -17,10 +17,12 @@ uint8_t lastButtonState = buttonState;
 unsigned long lastButtonPush = 0;
 uint8_t buttonThreshold = 50;
 
-// if you want to setup static ip uncomment these 3 lines and line 54
-//IPAddress strip_ip ( 192,  168,   10,  95);
-//IPAddress gateway_ip ( 192,  168,   10,   1);
-//IPAddress subnet_mask(255, 255, 255,   0);
+//#define USE_STATIC_IP //! uncomment to enable Static IP Adress
+#ifdef USE_STATIC_IP
+IPAddress strip_ip ( 192,  168,   0,  95); // choose an unique IP Adress
+IPAddress gateway_ip ( 192,  168,   0,   1); // Router IP
+IPAddress subnet_mask(255, 255, 255,   0);
+#endif
 
 bool device_state[devicesCount];
 byte mac[6];
@@ -51,8 +53,10 @@ void setup() {
 
   pinMode(ledPin, OUTPUT);
   digitalWrite(ledPin, HIGH);
-  //WiFi.config(strip_ip, gateway_ip, subnet_mask);
-
+  
+#ifdef USE_STATIC_IP
+  WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#endif
 
   if (EEPROM.read(1) == 1 || (EEPROM.read(1) == 0 && EEPROM.read(0) == 1)) {
     for (uint8_t i = 0; i < devicesCount; i++) {

--- a/Lights/Arduino/WS2811_adjustable/WS2811_adjustable.ino
+++ b/Lights/Arduino/WS2811_adjustable/WS2811_adjustable.ino
@@ -16,10 +16,12 @@
 #define button2_pin 5 // off and bri down
 #define use_hardware_switch false // on/off state and brightness can be controlled with above gpio pins. Is mandatory to connect them to ground with 10K resistors
 
-// if you want to setup static ip uncomment these 3 lines and line 326
-//IPAddress strip_ip ( 192,  168,   10,  95);
-//IPAddress gateway_ip ( 192,  168,   10,   1);
-//IPAddress subnet_mask(255, 255, 255,   0);
+//#define USE_STATIC_IP //! uncomment to enable Static IP Adress
+#ifdef USE_STATIC_IP
+IPAddress strip_ip ( 192,  168,   0,  95); // choose an unique IP Adress
+IPAddress gateway_ip ( 192,  168,   0,   1); // Router IP
+IPAddress subnet_mask(255, 255, 255,   0);
+#endif
 
 float rgb_multiplier[] = {100, 65, 30}; // light multiplier in percentage
 int lightLedsCount = pixelCount / lightsCount;
@@ -428,7 +430,9 @@ void setup() {
   EEPROM.begin(512);
   WiFi.hostname(light_name);
 
-  //WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#ifdef USE_STATIC_IP
+  WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#endif
 
   for (uint8_t light = 0; light < lightsCount; light++) {
     float transitiontime = (17 - (pixelCount / 40)) * 4;

--- a/Lights/Arduino/WS2812BHueRing/WS2812BHueRing.ino
+++ b/Lights/Arduino/WS2812BHueRing/WS2812BHueRing.ino
@@ -16,10 +16,12 @@ uint16_t pixelStart[lightsCount + 1] = {0, 1, 21, pixelCount};
 #define button1_pin 4 // on and bri up
 #define button2_pin 5 // off and bri down
 
-// if you want to setup static ip uncomment these 3 lines and line 325
-//IPAddress strip_ip ( 192,  168,   10,  95);
-//IPAddress gateway_ip ( 192,  168,   10,   1);
-//IPAddress subnet_mask(255, 255, 255,   0);
+//#define USE_STATIC_IP //! uncomment to enable Static IP Adress
+#ifdef USE_STATIC_IP
+IPAddress strip_ip ( 192,  168,   0,  95); // choose an unique IP Adress
+IPAddress gateway_ip ( 192,  168,   0,   1); // Router IP
+IPAddress subnet_mask(255, 255, 255,   0);
+#endif
 
 uint8_t rgb[lightsCount][3], bri[lightsCount], sat[lightsCount], color_mode[lightsCount], scene;
 bool light_state[lightsCount], in_transition;
@@ -322,7 +324,9 @@ void setup() {
   strip.Show();
   EEPROM.begin(512);
 
-  //WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#ifdef USE_STATIC_IP
+  WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#endif
 
   for (uint8_t light = 0; light < lightsCount; light++) {
     float transitiontime = (17 - (pixelCount / 40)) * 4;

--- a/Lights/Arduino/WS2812BHueStrip/WS2812BHueStrip.ino
+++ b/Lights/Arduino/WS2812BHueStrip/WS2812BHueStrip.ino
@@ -16,10 +16,12 @@
 #define button2_pin 5 // off and bri down
 #define use_hardware_switch false // on/off state and brightness can be controlled with above gpio pins. Is mandatory to connect them to ground with 10K resistors
 
-// if you want to setup static ip uncomment these 3 lines and line 326
-//IPAddress strip_ip ( 192,  168,   10,  95);
-//IPAddress gateway_ip ( 192,  168,   10,   1);
-//IPAddress subnet_mask(255, 255, 255,   0);
+//#define USE_STATIC_IP //! uncomment to enable Static IP Adress
+#ifdef USE_STATIC_IP
+IPAddress strip_ip ( 192,  168,   0,  95); // choose an unique IP Adress
+IPAddress gateway_ip ( 192,  168,   0,   1); // Router IP
+IPAddress subnet_mask(255, 255, 255,   0);
+#endif
 
 int lightLedsCount = pixelCount / lightsCount;
 uint8_t rgb[lightsCount][3], bri[lightsCount], sat[lightsCount], color_mode[lightsCount], scene;
@@ -398,7 +400,9 @@ void setup() {
   EEPROM.begin(512);
   WiFi.hostname(light_name);
 
-  //WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#ifdef USE_STATIC_IP
+  WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#endif
 
   for (uint8_t light = 0; light < lightsCount; light++) {
     float transitiontime = (17 - (pixelCount / 40)) * 4;

--- a/Lights/Arduino/fastLED_SM16726_RGBW_Bulb/fastLED_SM16726_RGBW_Bulb.ino
+++ b/Lights/Arduino/fastLED_SM16726_RGBW_Bulb/fastLED_SM16726_RGBW_Bulb.ino
@@ -62,10 +62,12 @@ extern "C"{
 #define W_ON_XY true
 
 
-// if you want to setup static ip uncomment these 3 lines and line 408
-//IPAddress strip_ip ( 192,  168,   10,  95);
-//IPAddress gateway_ip ( 192,  168,   10,   1);
-//IPAddress subnet_mask(255, 255, 255,   0);
+//#define USE_STATIC_IP //! uncomment to enable Static IP Adress
+#ifdef USE_STATIC_IP
+IPAddress strip_ip ( 192,  168,   0,  95); // choose an unique IP Adress
+IPAddress gateway_ip ( 192,  168,   0,   1); // Router IP
+IPAddress subnet_mask(255, 255, 255,   0);
+#endif
 
 const uint32_t period = 1024;
 
@@ -405,7 +407,10 @@ void setup() {
   
   pwm_init(period, pwm_duty_init, PWM_CHANNELS, io_info);
   pwm_start();
-  //WiFi.config(strip_ip, gateway_ip, subnet_mask);
+  
+#ifdef USE_STATIC_IP
+  WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#endif
 
   apply_scene(EEPROM.read(2));
   step_level[0] = rgbw[0] / 150.0; step_level[1] = rgbw[1] / 150.0; step_level[2] = rgbw[2] / 150.0; step_level[3] = rgbw[3] / 150.0;

--- a/Lights/Arduino/sk6812_wwa/sk6812_wwa.ino
+++ b/Lights/Arduino/sk6812_wwa/sk6812_wwa.ino
@@ -11,10 +11,12 @@
 #define pixelCount 144
 
 
-// if you want to setup static ip uncomment these 3 lines and line 154
-//IPAddress strip_ip ( 192,  168,   10,  95);
-//IPAddress gateway_ip ( 192,  168,   10,   1);
-//IPAddress subnet_mask(255, 255, 255,   0);
+//#define USE_STATIC_IP //! uncomment to enable Static IP Adress
+#ifdef USE_STATIC_IP
+IPAddress strip_ip ( 192,  168,   0,  95); // choose an unique IP Adress
+IPAddress gateway_ip ( 192,  168,   0,   1); // Router IP
+IPAddress subnet_mask(255, 255, 255,   0);
+#endif
 
 uint8_t wwa[lightsCount][3], bri[lightsCount], scene;
 bool light_state[lightsCount], in_transition;
@@ -151,7 +153,9 @@ void setup() {
   strip.Show();
   EEPROM.begin(512);
 
-  //WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#ifdef USE_STATIC_IP
+  WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#endif
 
   for (uint8_t light = 0; light < lightsCount; light++) {
     float transitiontime = (17 - (pixelCount / 40)) * 4;

--- a/Lights/PlatformIO/Generic_CCT_Light/src/Generic_CCT_Light.cpp
+++ b/Lights/PlatformIO/Generic_CCT_Light/src/Generic_CCT_Light.cpp
@@ -26,10 +26,12 @@ uint32 io_info[PWM_CHANNELS][3] = {
 uint32 pwm_duty_init[PWM_CHANNELS] = {0, 0};
 
 
-// if you want to setup static ip uncomment these 3 lines and line 72
-//IPAddress strip_ip ( 192,  168,   10,  95);
-//IPAddress gateway_ip ( 192,  168,   10,   1);
-//IPAddress subnet_mask(255, 255, 255,   0);
+//#define USE_STATIC_IP //! uncomment to enable Static IP Adress
+#ifdef USE_STATIC_IP
+IPAddress strip_ip ( 192,  168,   0,  95); // choose an unique IP Adress
+IPAddress gateway_ip ( 192,  168,   0,   1); // Router IP
+IPAddress subnet_mask(255, 255, 255,   0);
+#endif
 
 uint8_t cct[2], scene;
 bool light_state, in_transition;
@@ -115,7 +117,9 @@ void setup() {
   pwm_init(period, pwm_duty_init, PWM_CHANNELS, io_info);
   pwm_start();
 
-  //WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#ifdef USE_STATIC_IP
+  WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#endif
 
   apply_scene(EEPROM.read(2));
   step_level[0] = cct[0] / 150.0; step_level[1] = cct[1] / 150.0; step_level[2] = cct[2] / 150.0; step_level[3] = cct[3] / 150.0;

--- a/Lights/PlatformIO/Generic_RGBW_Light/src/Generic_RGBW_Light.cpp
+++ b/Lights/PlatformIO/Generic_RGBW_Light/src/Generic_RGBW_Light.cpp
@@ -24,10 +24,12 @@ uint32 io_info[PWM_CHANNELS][3] = {
 // initial duty: all off
 uint32 pwm_duty_init[PWM_CHANNELS] = {0, 0, 0, 0};
 
-// if you want to setup static ip uncomment these 3 lines and line 72
-//IPAddress strip_ip ( 192,  168,   10,  95);
-//IPAddress gateway_ip ( 192,  168,   10,   1);
-//IPAddress subnet_mask(255, 255, 255,   0);
+//#define USE_STATIC_IP //! uncomment to enable Static IP Adress
+#ifdef USE_STATIC_IP
+IPAddress strip_ip ( 192,  168,   0,  95); // choose an unique IP Adress
+IPAddress gateway_ip ( 192,  168,   0,   1); // Router IP
+IPAddress subnet_mask(255, 255, 255,   0);
+#endif
 
 uint8_t rgbw[4], color_mode, scene;
 bool light_state, in_transition;
@@ -239,7 +241,9 @@ void setup() {
   pwm_init(period, pwm_duty_init, PWM_CHANNELS, io_info);
   pwm_start();
 
-  //WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#ifdef USE_STATIC_IP
+  WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#endif
 
   apply_scene(EEPROM.read(2));
   step_level[0] = rgbw[0] / 150.0; step_level[1] = rgbw[1] / 150.0; step_level[2] = rgbw[2] / 150.0; step_level[3] = rgbw[3] / 150.0;

--- a/Lights/PlatformIO/Generic_RGB_CCT_Light/src/Generic_RGB_CCT_Light.cpp
+++ b/Lights/PlatformIO/Generic_RGB_CCT_Light/src/Generic_RGB_CCT_Light.cpp
@@ -26,10 +26,12 @@ uint32 io_info[PWM_CHANNELS][3] = {
 uint32 pwm_duty_init[PWM_CHANNELS] = {0, 0, 0, 0, 0};
 
 
-// if you want to setup static ip uncomment these 3 lines and line 72
-//IPAddress strip_ip ( 192,  168,   10,  95);
-//IPAddress gateway_ip ( 192,  168,   10,   1);
-//IPAddress subnet_mask(255, 255, 255,   0);
+//#define USE_STATIC_IP //! uncomment to enable Static IP Adress
+#ifdef USE_STATIC_IP
+IPAddress strip_ip ( 192,  168,   0,  95); // choose an unique IP Adress
+IPAddress gateway_ip ( 192,  168,   0,   1); // Router IP
+IPAddress subnet_mask(255, 255, 255,   0);
+#endif
 
 uint8_t rgb_cct[5], color_mode, scene;
 bool light_state, in_transition;
@@ -235,7 +237,9 @@ void setup() {
   pwm_init(period, pwm_duty_init, PWM_CHANNELS, io_info);
   pwm_start();
 
-  //WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#ifdef USE_STATIC_IP
+  WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#endif
 
   apply_scene(EEPROM.read(2));
   step_level[0] = rgb_cct[0] / 150.0; step_level[1] = rgb_cct[1] / 150.0; step_level[2] = rgb_cct[2] / 150.0; step_level[3] = rgb_cct[3] / 150.0; step_level[4] = rgb_cct[4] / 150.0;

--- a/Lights/PlatformIO/Generic_RGB_Light/src/Generic_RGB_Light.cpp
+++ b/Lights/PlatformIO/Generic_RGB_Light/src/Generic_RGB_Light.cpp
@@ -24,10 +24,12 @@ uint32 io_info[PWM_CHANNELS][3] = {
 // initial duty: all off
 uint32 pwm_duty_init[PWM_CHANNELS] = {0, 0, 0};
 
-// if you want to setup static ip uncomment these 3 lines and line 72
-//IPAddress strip_ip ( 192,  168,   10,  95);
-//IPAddress gateway_ip ( 192,  168,   10,   1);
-//IPAddress subnet_mask(255, 255, 255,   0);
+//#define USE_STATIC_IP //! uncomment to enable Static IP Adress
+#ifdef USE_STATIC_IP
+IPAddress strip_ip ( 192,  168,   0,  95); // choose an unique IP Adress
+IPAddress gateway_ip ( 192,  168,   0,   1); // Router IP
+IPAddress subnet_mask(255, 255, 255,   0);
+#endif
 
 uint8_t rgb[3], color_mode, scene;
 bool light_state, in_transition;
@@ -275,7 +277,9 @@ void setup() {
   pwm_init(period, pwm_duty_init, PWM_CHANNELS, io_info);
   pwm_start();
 
-  //WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#ifdef USE_STATIC_IP
+  WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#endif
 
   apply_scene(EEPROM.read(2));
   step_level[0] = rgb[0] / 150.0; step_level[1] = rgb[1] / 150.0; step_level[2] = rgb[2] / 150.0; step_level[3] = rgb[3] / 150.0;

--- a/Lights/PlatformIO/SK6812HueStrip/src/SK6812HueStrip.cpp
+++ b/Lights/PlatformIO/SK6812HueStrip/src/SK6812HueStrip.cpp
@@ -12,10 +12,12 @@
 #define lightsCount 3
 #define pixelCount 30
 
-// if you want to setup static ip uncomment these 3 lines and line 72
-//IPAddress strip_ip ( 192,  168,   10,  95);
-//IPAddress gateway_ip ( 192,  168,   10,   1);
-//IPAddress subnet_mask(255, 255, 255,   0);
+//#define USE_STATIC_IP //! uncomment to enable Static IP Adress
+#ifdef USE_STATIC_IP
+IPAddress strip_ip ( 192,  168,   0,  95); // choose an unique IP Adress
+IPAddress gateway_ip ( 192,  168,   0,   1); // Router IP
+IPAddress subnet_mask(255, 255, 255,   0);
+#endif
 
 uint8_t rgbw[lightsCount][4], color_mode[lightsCount], scene;
 bool light_state[lightsCount], in_transition;
@@ -254,7 +256,9 @@ void setup() {
   strip.Show();
   EEPROM.begin(512);
 
-  //WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#ifdef USE_STATIC_IP
+  WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#endif
 
   for (uint8_t light = 0; light < lightsCount; light++) {
     float transitiontime = (16 - (pixelCount / 40)) * 4;

--- a/Lights/PlatformIO/WS2812BHueStrip/src/WS2812BHueStrip.ino
+++ b/Lights/PlatformIO/WS2812BHueStrip/src/WS2812BHueStrip.ino
@@ -12,10 +12,12 @@
 #define lightsCount 3
 #define pixelCount 60
 
-// if you want to setup static ip uncomment these 3 lines and line 72
-//IPAddress strip_ip ( 192,  168,   10,  95);
-//IPAddress gateway_ip ( 192,  168,   10,   1);
-//IPAddress subnet_mask(255, 255, 255,   0);
+//#define USE_STATIC_IP //! uncomment to enable Static IP Adress
+#ifdef USE_STATIC_IP
+IPAddress strip_ip ( 192,  168,   0,  95); // choose an unique IP Adress
+IPAddress gateway_ip ( 192,  168,   0,   1); // Router IP
+IPAddress subnet_mask(255, 255, 255,   0);
+#endif
 
 uint8_t rgb[lightsCount][3], color_mode[lightsCount], scene;
 bool light_state[lightsCount], in_transition;
@@ -255,7 +257,9 @@ void setup() {
   strip.Show();
   EEPROM.begin(512);
 
-  //WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#ifdef USE_STATIC_IP
+  WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#endif
 
   for (uint8_t light = 0; light < lightsCount; light++) {
     float transitiontime = (17 - (pixelCount / 40)) * 4;

--- a/Sensors/HueDimmerSwitch/HueDimmerSwitch.ino
+++ b/Sensors/HueDimmerSwitch/HueDimmerSwitch.ino
@@ -18,11 +18,11 @@ const char* switchType = "ZLLSwitch";
 const char* bridge_user = "9f552609847c0dd1f372fee9b76330035b7a3bb1";
 
 //Set bridge ip or ip of every light controlled by this switch
-
 const char* bridgeIp[] = {"192.168.10.200"};
 
-IPAddress strip_ip ( 192,  168,   10,  96);
-IPAddress gateway_ip ( 192,  168,   10,   1);
+//static ip configuration is necessary to minimize bootup time from deep sleep
+IPAddress strip_ip ( 192,  168,   0,  95); // choose an unique IP Adress
+IPAddress gateway_ip ( 192,  168,   0,   1); // Router IP
 IPAddress subnet_mask(255, 255, 255,   0);
 
 int counter;

--- a/Sensors/HueMotionSensor/HueMotionSensor.ino
+++ b/Sensors/HueMotionSensor/HueMotionSensor.ino
@@ -19,8 +19,9 @@ const int sleepTimeS = 1200; // 1200 seconds => 20 minutes
 // depending on photoresistor you need to setup this value to trigger dark state when light level in room become low enough
 #define lightmultiplier 30
 
-IPAddress strip_ip ( 192,  168,   10,  97);
-IPAddress gateway_ip ( 192,  168,   10,   1);
+//static ip configuration is necessary to minimize bootup time from deep sleep
+IPAddress strip_ip ( 192,  168,   0,  95); // choose an unique IP Adress
+IPAddress gateway_ip ( 192,  168,   0,   1); // Router IP
 IPAddress subnet_mask(255, 255, 255,   0);
 
 /// END SETUP SENSOR PARAMETERS ////

--- a/Sensors/HueSensorStandardLightSwitch/Arduino/HueSensorStandardLightSwitchV2/HueSensorStandardLightSwitchV2.ino
+++ b/Sensors/HueSensorStandardLightSwitch/Arduino/HueSensorStandardLightSwitchV2/HueSensorStandardLightSwitchV2.ino
@@ -28,9 +28,12 @@ const char* bridgeIp = "192.168.178.45";
 //Static adresses are no longer needed, because we use a Powersupply!
 //DHCP FTW :)
 
-//IPAddress strip_ip ( 192,  168,   10,  96);
-//IPAddress gateway_ip ( 192,  168,   10,   1);
-//IPAddress subnet_mask(255, 255, 255,   0);
+//#define USE_STATIC_IP //! uncomment to enable Static IP Adress
+#ifdef USE_STATIC_IP
+IPAddress strip_ip ( 192,  168,   0,  95); // choose an unique IP Adress
+IPAddress gateway_ip ( 192,  168,   0,   1); // Router IP
+IPAddress subnet_mask(255, 255, 255,   0);
+#endif
 
 int counter;
 byte mac[6];
@@ -135,7 +138,11 @@ void setup() {
 
   WiFi.mode(WIFI_STA);
   WiFi.begin(ssid, password);
-  //WiFi.config(strip_ip, gateway_ip, subnet_mask);
+  
+#ifdef USE_STATIC_IP
+  WiFi.config(strip_ip, gateway_ip, subnet_mask);
+#endif
+
   WiFi.macAddress(mac);
 
   while (WiFi.status() != WL_CONNECTED) {

--- a/Sensors/HueTapSwitch/HueTapSwitch.ino
+++ b/Sensors/HueTapSwitch/HueTapSwitch.ino
@@ -19,8 +19,9 @@ const char* switchType = "ZGPSwitch";
 
 const char* bridgeIp = "192.168.10.200";
 
-IPAddress strip_ip ( 192,  168,   10,  96);
-IPAddress gateway_ip ( 192,  168,   10,   1);
+//static ip configuration is necessary to minimize bootup time from deep sleep
+IPAddress strip_ip ( 192,  168,   0,  95); // choose an unique IP Adress
+IPAddress gateway_ip ( 192,  168,   0,   1); // Router IP
 IPAddress subnet_mask(255, 255, 255,   0);
 
 int counter;


### PR DESCRIPTION
using defines is more user friendly as the user does not have to search for the commented lines.
