### PR TITLE
Use white LED on convert_ct()

### DIFF
--- a/Lights/Arduino/Generic_RGBW_Light/Generic_RGBW_Light.ino
+++ b/Lights/Arduino/Generic_RGBW_Light/Generic_RGBW_Light.ino
@@ -23,7 +23,7 @@
 #define button2_pin 3 // off and brightness down
 
 //define pins
-uint8_t pins[PWM_CHANNELS] = {12, 5, 13, 15}; //red, green, blue, white
+uint8_t pins[PWM_CHANNELS] = {12, 13, 14, 5}; //red, green, blue, white
 
 //#define USE_STATIC_IP //! uncomment to enable Static IP Adress
 #ifdef USE_STATIC_IP

--- a/Lights/Arduino/Generic_RGBW_Light/Generic_RGBW_Light.ino
+++ b/Lights/Arduino/Generic_RGBW_Light/Generic_RGBW_Light.ino
@@ -11,6 +11,10 @@
 
 #define light_name "Hue RGBW Light" // Light name, change this if you se multiple lights for easy identification
 
+// Define your white led color temp here (Range 2000-6536K).
+// For warm-white led try 2000K, for cold-white try 6000K
+#define WHITE_TEMP 2000 // kelvin
+
 #define PWM_CHANNELS 4
 
 #define use_hardware_switch false // To control on/off state and brightness using GPIO/Pushbutton, set this value to true.
@@ -19,7 +23,7 @@
 #define button2_pin 3 // off and brightness down
 
 //define pins
-uint8_t pins[PWM_CHANNELS] = {12, 13, 14, 5}; //red, green, blue, white
+uint8_t pins[PWM_CHANNELS] = {12, 5, 13, 15}; //red, green, blue, white
 
 //#define USE_STATIC_IP //! uncomment to enable Static IP Adress
 #ifdef USE_STATIC_IP
@@ -150,6 +154,19 @@ void convert_xy()
   colors[0] = (int) (r * optimal_bri); colors[1] = (int) (g * optimal_bri); colors[2] = (int) (b * optimal_bri); colors[3] = 0;
 }
 
+/**
+ * Last change by: YannikW, 03.10.18
+ * 
+ * This converts a CT to a mix of a white led with a color temperature defines in WHITE_TEMP,
+ * plus RGB shades to achieve full white spectrum.
+ * CT value is in mired: https://en.wikipedia.org/wiki/Mired
+ * Range is between 153 (equals 6536K cold-white) and 500 (equals 2000K warm-white)
+ * 
+ * To shift the white led to warmer or colder white shades we mix a "RGB-white" to the white led.
+ * This RGB white is calculated as in old convert_ct methode, with formulars by: http://www.tannerhelland.com/4435/convert-temperature-rgb-algorithm-code/
+ * If the desired CT equals the white channel CT, we add 0% RGB-white, the more we shift away we add more RGB-white. 
+ * At the lower or higher end we add 100% RGB-white and reduce the led-white down to 50%
+ */
 void convert_ct() {
   int optimal_bri = int( 10 + bri / 1.04);
   int hectemp = 10000 / ct;
@@ -166,7 +183,29 @@ void convert_ct() {
   r = r > 255 ? 255 : r;
   g = g > 255 ? 255 : g;
   b = b > 255 ? 255 : b;
-  colors[0] = r * (optimal_bri / 255.0f); colors[1] = g * (optimal_bri / 255.0f); colors[2] = b * (optimal_bri / 255.0f);
+
+
+  // calculate mix factor
+  double mixFactor;
+  int temp = hectemp*100;
+  if(temp >= WHITE_TEMP) {
+    // mix cold-rgb-white to led-white
+    mixFactor = (double)(temp-WHITE_TEMP) / (6536.0-WHITE_TEMP);  //0.0 - 1.0
+  }
+  else {
+    // mix warm-rgb-white to led-white
+    mixFactor = (double)(WHITE_TEMP-temp) / (WHITE_TEMP-2000.0);  //0.0 - 1.0
+  }
+  // constrain to 0-1
+  mixFactor = mixFactor > 1.0 ? 1.0 : mixFactor;
+  mixFactor = mixFactor < 0.0 ? 0.0 : mixFactor;
+  
+  colors[0] = r * (optimal_bri / 255.0f) * mixFactor; 
+  colors[1] = g * (optimal_bri / 255.0f) * mixFactor; 
+  colors[2] = b * (optimal_bri / 255.0f) * mixFactor;
+  
+  // reduce white brightness by 50% on maximum mixFactor 
+  colors[3] = optimal_bri * (1.0-(mixFactor*0.5));
 }
 
 void handleNotFound() {


### PR DESCRIPTION
A few days ago I got help with an issue, so now I wanna contribute to this project :)

I noticed that the white led on a RGBW strip isn't used at all.

I changed the calculation when a white-shade is selected (color mode is unchanged).

In the beginning of the code you can enter the colortemp of your led (for strips with warm or cold-white leds).

If the user selected color-temp matches the color temp of the white led - only the white led lights and RGB channels are off.

For a different user selected color temp it's now a mix between white led, and a white shade, created with the RGB leds. This white shade with RGB is the same calculation at it was before.
On maximum difference between user-color-temp and white-led-color-temp the white channel dimms down to 50% and RGB-white brightness is 100%.

An example:
The colortemp of the white led is 3000K.

| User color-temp | White brightness | RGB-white brightness |
| --- | --- | --- |
| 2000K | 50% | 100% |
| 2500K | 75% | 50% |
| 3000K | 100% | 0% |
| 6536K | 50% | 100% |

This approach isn't (EDIT: sorry - the _not_ was missing) very scientific, but I tested it with my RGBW strip and the white shades looks much better as without using the white led.

I hope this will be usefull! :)