### PR TITLE
Remove sleep(1)

### DIFF
--- a/BridgeEmulator/HueEmulator3.py
+++ b/BridgeEmulator/HueEmulator3.py
@@ -662,6 +662,8 @@ def sendLightRequest(light, data):
                     del(payload["sat"])
                 if len(payload) != 0:
                     sendRequest(url, method, json.dumps(payload))
+                    if bridge_config["lights_address"][light]["protocol"] == "deconz":
+                        sleep(0.7)
                 if len(color) != 0:
                     sendRequest(url, method, json.dumps(color))
             else:

--- a/BridgeEmulator/HueEmulator3.py
+++ b/BridgeEmulator/HueEmulator3.py
@@ -662,7 +662,6 @@ def sendLightRequest(light, data):
                     del(payload["sat"])
                 if len(payload) != 0:
                     sendRequest(url, method, json.dumps(payload))
-                    sleep(1)
                 if len(color) != 0:
                     sendRequest(url, method, json.dumps(color))
             else:


### PR DESCRIPTION
Hi, 
I found that the line 665 with sleep(1) was causing delay when used with real Hue bridge.
When removing this line i have no more delay in entertainment mode and dimming my philips hue lights connected to real bridge. 

Does this line really necessary ? 
Cédric